### PR TITLE
Fix verbs and names appending incorrectly in double loop

### DIFF
--- a/lib/src/words.dart
+++ b/lib/src/words.dart
@@ -76,11 +76,7 @@ class WordGenerator {
     final random = Random();
     final verbsRes = <String>[];
     for (var i = 0; i < count; i++) {
-      var verb = '';
-      for (var j = 0; j < count; j++) {
-        verb += verbs[random.nextInt(verbs.length)];
-      }
-      verbsRes.add(verb);
+      verbsRes.add(verbs[random.nextInt(verbs.length)]);
     }
     return verbsRes;
   }
@@ -101,11 +97,7 @@ class WordGenerator {
     final random = Random();
     final namesRes = <String>[];
     for (var i = 0; i < count; i++) {
-      var name = '';
-      for (var j = 0; j < count; j++) {
-        name += names[random.nextInt(names.length)];
-      }
-      namesRes.add(name);
+      namesRes.add(names[random.nextInt(names.length)]);
     }
     return namesRes;
   }

--- a/test/word_generator_test.dart
+++ b/test/word_generator_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:word_generator/word_generator.dart';
+import 'package:word_generator/data/verbs.dart' as verbs_data;
+import 'package:word_generator/data/names.dart' as names_data;
 
 void main() {
   test('randomNoun', () {
@@ -20,5 +22,29 @@ void main() {
   test('randomNouns', () {
     final wordGenerator = WordGenerator();
     expect(wordGenerator.randomNouns(5).length, 5);
+  });
+
+  test('randomNames', () {
+    final wordGenerator = WordGenerator();
+    expect(wordGenerator.randomNames(5).length, 5);
+  });
+
+  test('randomNamesNotAppended', () {
+    final wordGenerator = WordGenerator();
+    final names = wordGenerator.randomNames(5);
+
+    expect(names.every((name) => names_data.names.contains(name)), isTrue);
+  });
+
+   test('randomVerbs', () {
+    final wordGenerator = WordGenerator();
+    expect(wordGenerator.randomVerbs(5).length, 5);
+  });
+
+  test('randomVerbsNotAppended', () {
+    final wordGenerator = WordGenerator();
+    final verbs = wordGenerator.randomVerbs(5);
+
+    expect(verbs.every((verb) => verbs_data.verbs.contains(verb)), isTrue);
   });
 }


### PR DESCRIPTION
Fix verbs and names appending incorrectly in double loop when calling `randomNames(n)` and `randomVerbs(n)`.

And added tests.

Fixes KathirvelChandrasekaran/word_generator#9